### PR TITLE
Updated TFA port to prompt with currently enabled TFA Plugin form.

### DIFF
--- a/src/Form/EntryForm.php
+++ b/src/Form/EntryForm.php
@@ -24,7 +24,8 @@ class EntryForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state, AccountInterface $user = null) {
-    $tfa = _tfa_get_process($user);
+    $tfaManager = \Drupal::service('tfa.manager');
+    $tfa = $tfaManager->getProcess($user);
 
 
     // Check flood tables.
@@ -63,7 +64,8 @@ class EntryForm extends FormBase {
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
     $user = $form_state->getValue('account');
-    $tfa = _tfa_get_process($user);
+    $tfaManager = \Drupal::service('tfa.manager');
+    $tfa = $tfaManager->getProcess($user);
     $tfa->validateForm($form, $form_state);
   }
 
@@ -72,7 +74,8 @@ class EntryForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $user = $form_state->getValue('account');
-    $tfa = _tfa_get_process($user);
+    $tfaManager = \Drupal::service('tfa.manager');
+    $tfa = $tfaManager->getProcess($user);
     if(!$tfa->submitForm($form, $form_state)) {
       // If fallback was triggered TFA process has been reset to new validate
       // plugin so run begin and store new context.
@@ -82,14 +85,14 @@ class EntryForm extends FormBase {
         $tfa->begin();
       }
       $context = $tfa->getContext();
-      tfa_set_context($user, $context);
+      $tfaManager->setContext($user, $context);
       $form_state['rebuild'] = TRUE;
     }
     else {
       // TFA process is complete so finalize and authenticate user.
-      $context = _tfa_get_context($user);
+      $context = $tfaManager->getContext($user);
       $tfa->finalize();
-      _tfa_login($user);
+      $tfaManager->login($user);
       // Set redirect based on query parameters, existing $form_state or context.
       //$form_state['redirect'] = _tfa_form_get_destination($context, $form_state, $user);
       $form_state->setRedirect('<front>');

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -69,6 +69,7 @@ class SettingsForm extends ConfigFormBase {
       '#description' => t('Enable TFA for account authentication.'),
     );
 
+    //@TODO Figure out why we allow multiple validation plugins?
     if (count($validate_plugins)) {
 
       //order plugins by weight

--- a/src/Plugin/EncryptionMethod/McryptAES128Encryption.php
+++ b/src/Plugin/EncryptionMethod/McryptAES128Encryption.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\encrypt\Plugin\EncryptionMethod;
+
+use Drupal\encrypt\EncryptionMethodInterface;
+use Drupal\Core\Plugin\PluginBase;
+
+/**
+ * Class McryptAES128Encryption
+ * @package Drupal\encrypt\Plugin\EncryptionMethod
+ *
+ * @EncryptionMethod(
+ *   id = "mcrypt_aes_128",
+ *   title = @Translation("Mcrypt AES 128"),
+ *   description = "This uses PHPs mcrypt extension and <a href='http://en.wikipedia.org/wiki/Advanced_Encryption_Standard'>AES-128</a>."
+ * )
+ */
+class McryptAES128Encryption extends PluginBase implements EncryptionMethodInterface {
+
+  /**
+   * @return mixed
+   */
+  public function getDependencies() {
+    $errors = array();
+
+    if (!function_exists('mcrypt_encrypt')) {
+      $errors[] = t('MCrypt library not installed.');
+    }
+
+    return $errors;
+  }
+
+  /**
+   * @return mixed
+   */
+  public function encrypt($text, $key, $options = array()) {
+    $processed_text = '';
+
+    // Key cannot be too long for this encryption.
+    $key = \Drupal\Component\Utility\Unicode::substr($key, 0, 32);
+
+    // Define iv cipher.
+    $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_ECB);
+    $iv = mcrypt_create_iv($iv_size, MCRYPT_RAND);
+    $disable_base64 = array_key_exists('base64', $options) && $options['base64'] == FALSE;
+
+    $processed_text = mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $key, $text, MCRYPT_MODE_ECB, $iv);
+
+    // Check if we are disabling base64 encoding
+    if (!$disable_base64) {
+      $processed_text = base64_encode($processed_text);
+    }
+
+    return $processed_text;
+  }
+
+  /**
+   * @return mixed
+   */
+  public function decrypt($text, $key, $options = array()) {
+    $processed_text = '';
+
+    // Key cannot be too long for this encryption.
+    $key = \Drupal\Component\Utility\Unicode::substr($key, 0, 32);
+
+    // Define iv cipher.
+    $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_ECB);
+    $iv = mcrypt_create_iv($iv_size, MCRYPT_RAND);
+    $disable_base64 = array_key_exists('base64', $options) && $options['base64'] == FALSE;
+
+    // Check if we are disabling base64 encoding
+    if (!$disable_base64) {
+      $text = base64_decode($text);
+    }
+
+    // Decrypt text.
+    return trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $key, $text, MCRYPT_MODE_ECB, $iv));
+  }
+}

--- a/src/Plugin/TfaValidationInterface.php
+++ b/src/Plugin/TfaValidationInterface.php
@@ -24,7 +24,7 @@ interface TfaValidationInterface {
    * @param FormStateInterface $form_state
    * @return array Form API array.
    */
-  public function getForm(array $form, FormStateInterface &$form_state);
+  public function getForm(array $form, FormStateInterface $form_state);
 
   /**
    * Validate form.
@@ -33,5 +33,5 @@ interface TfaValidationInterface {
    * @param FormStateInterface $form_state
    * @return bool Whether form passes validation or not
    */
-  public function validateForm(array $form, FormStateInterface &$form_state);
+  public function validateForm(array $form, FormStateInterface $form_state);
 }

--- a/src/Tfa.php
+++ b/src/Tfa.php
@@ -91,7 +91,6 @@ class Tfa {
           array('@function' => 'Tfa::__construct')));
     }
 
-
     //How do we dynamically load the validate plugin class?
     $validation_service = \Drupal::service('plugin.manager.tfa.validation');
     $validate_plugin = $validation_service->getDefinition($plugins['validate']);

--- a/src/TfaManager.php
+++ b/src/TfaManager.php
@@ -206,7 +206,7 @@ class TfaManager {
           );
         }
         else {
-          $requestStack->getCurrentRequest()->query->set('destination', $this->getRequest()->request->get('destination'));
+          $requestStack->getCurrentRequest()->query->set('destination',  $requestStack->request->get('destination'));
         }
 
         user_login_finalize($account);

--- a/src/TfaManager.php
+++ b/src/TfaManager.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * @file TfaManager
+ * Contains the TfaManager service.
+ */
+
+namespace Drupal\tfa;
+
+
+use Drupal\tfa\Tfa;
+use Drupal\user\Entity\User;
+use Drupal\Component\Utility\Crypt;
+
+
+class TfaManager {
+
+
+  /**
+   * Get Tfa object in the account's current context.
+   *
+   * @param $account User account object
+   * @return Tfa
+   */
+  //function _tfa_get_process($account) {
+  public function getProcess($account) {
+    $tfa = &drupal_static(__FUNCTION__);
+    if (!isset($tfa)) {
+      $context = $this->getContext($account);
+      if (empty($context['plugins'])) {
+        $context = $this->startContext($account);
+      }
+      try {
+        // instansiate all plugins
+        $tfa = new Tfa($context['plugins'], $context);
+      } catch (\Exception $e) {
+        $tfa = FALSE;
+      }
+    }
+    return $tfa;
+  }
+
+  /**
+   * Context for account TFA process.
+   *
+   * @param User $account
+   * @return array
+   * @see _tfa_start_context() for format
+   */
+  //function _tfa_get_context(User $account) {
+  public function getContext(User $account) {
+    $context = array();
+//  if (isset($_SESSION['tfa'][$account->id()])) {
+//    $context = $_SESSION['tfa'][$account->id()];
+//  }
+    // Allow other modules to modify TFA context.
+    \Drupal::moduleHandler()->alter('tfa_context', $context);
+    return $context;
+  }
+
+
+
+
+  /**
+   * Start context for TFA.
+   *
+   * @param User $account
+   * @return array
+   *   array(
+   *     'uid' => 9,
+   *     'plugins' => array(
+   *       'validate' => 'TfaMySendPlugin',
+   *       'login' => arrray('TfaMyLoginPlugin'),
+   *       'fallback' => array('TfaMyRecoveryCodePlugin'),
+   *       'setup' => 'TfaMySetupPlugin',
+   *     ),
+   *
+   *
+   * @TODO TBD on purpose of $api defines the class name of the plugins, but we need to load
+   * them by the plugin name. Is it actually doing us any good?
+   */
+  //function _tfa_start_context($account) {
+  public function startContext($account) {
+    $context = array('uid' => $account->id(), 'plugins' => array());
+    $plugins = array();
+    $fallback_plugins = array();
+
+    $api = \Drupal::moduleHandler()->invokeAll('tfa_api', []);
+    $settings = \Drupal::config('tfa.settings');
+    if (\Drupal::config('tfa.settings')->get('login_plugins')) {
+      $plugins = \Drupal::config('tfa.settings')->get('login_plugins');
+    }
+
+    if (\Drupal::config('tfa.settings')->get('fallback_plugins')) {
+      $fallback_plugins = \Drupal::config('tfa.settings')->get('fallback_plugins');
+    }
+
+    // Add login plugins.
+    //@TODO This won't work the way it is. Need to refactor like we did for validate plguins.
+    foreach ($plugins as $key) {
+      if (array_key_exists($key, $api)) {
+        $context['plugins']['login'][] = $api[$key]['class'];
+      }
+    }
+    // Add validate.
+    //@TODO Figure out why D8 decided to allow multiple validate plugins.
+    $validate = \Drupal::config('tfa.settings')->get('validate_plugins');
+    foreach($validate as $key => $value){
+      if (!empty($validate) && array_key_exists($key, $api)) {
+        $context['plugins']['validate'] = $key;
+      }
+    }
+
+    // Add fallback plugins.
+    foreach ($fallback_plugins as $key) {
+      if (array_key_exists($key, $api)) {
+        $context['plugins']['fallback'][] = $api[$key]['class'];
+      }
+    }
+    // Allow other modules to modify TFA context.
+    \Drupal::moduleHandler()->alter('tfa_context', $context);
+    $this->setContext($account, $context);
+    return $context;
+  }
+
+  /**
+   * Set context for account's TFA process.
+   *
+   * @param $account User account
+   * @param array $context Context array
+   * @see tfa_start_context() for context format
+   */
+  public function setContext($account, $context) {
+    $_SESSION['tfa'][$account->id()] = $context;
+    $_SESSION['tfa'][$account->id()]['uid'] = $account->id();
+    // Clear existing static TFA process.
+    drupal_static_reset('tfa_get_process');
+  }
+
+  /**
+   * Check if TFA process has completed so authentication should not be stopped.
+   *
+   * @param $account User account
+   * @return bool
+   */
+  //function _tfa_login_complete($account) {
+  public function loginComplete($account) {
+    // TFA master login allowed switch is set by tfa_login().
+    if (isset($_SESSION['tfa'][$account->uid]['login']) && $_SESSION['tfa'][$account->uid]['login'] === TRUE) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Generate account hash to access the TFA form.
+   *
+   * @param object $account User account.
+   * @return string Random hash.
+   */
+  //function tfa_login_hash($account) {
+  public function getLoginHash($account) {
+    // Using account login will mean this hash will become invalid once user has
+    // authenticated via TFA.
+    $data = implode(':', array($account->getUsername() , $account->getPassword(), $account->getLastLoginTime()));
+    return Crypt::hashBase64($data);
+  }
+
+
+  /**
+   * Authenticate the user.
+   *
+   * Does basically the same thing that user_login_finalize does but with our own custom
+   * hooks.
+   *
+   * @param $account User account object.
+   */
+  //function _tfa_login($account) {
+  public function login($account) {
+    \Drupal::currentUser()->setAccount($account);
+
+    // Update the user table timestamp noting user has logged in.
+    $account->setLastLoginTime(REQUEST_TIME);
+    \Drupal::entityManager()
+      ->getStorage('user')
+      ->updateLastLoginTimestamp($account);
+    // Regenerate the session ID to prevent against session fixation attacks.
+    \Drupal::service('session')->migrate();
+    \Drupal::service('session')->set('uid', $account->id());
+
+    //watchdog('tfa', 'Session opened for %name.', array('%name' => $user->getUsername()));
+    // Clear existing context and set master authenticated context.
+    $this->clearContext($account);
+    $_SESSION['tfa'][$account->id()]['login'] = TRUE;
+
+    // Truncate flood for user.
+    //flood_clear_event('tfa_begin');
+    //$identifier = variable_get('user_failed_login_identifier_uid_only', FALSE) ? $account->uid : $account->uid . '-' . ip_address();
+    //flood_clear_event('tfa_user', $identifier);
+    //$edit = array();
+    //user_module_invoke('login', $edit, $user);
+  }
+
+  /**
+   * Remove context for account.
+   *
+   * @param object $account
+   *   User account object
+   */
+  public function clearContext($account) {
+    unset($_SESSION['tfa'][$account->uid]);
+  }
+
+
+}

--- a/src/TfaManager.php
+++ b/src/TfaManager.php
@@ -211,4 +211,15 @@ class TfaManager {
   }
 
 
+  /**
+   * Validate access to TFA code entry form.
+   */
+  public function entryAccess($account, $url_hash) {
+    // Generate a hash for this account.
+    //$hash = tfa_login_hash($account);
+    //$context = tfa_get_context($account);
+    //return $hash === $url_hash && !empty($context) && $context['uid'] === $account->uid;
+    return TRUE;
+  }
+
 }

--- a/src/TfaValidationPluginManager.php
+++ b/src/TfaValidationPluginManager.php
@@ -30,7 +30,7 @@ class TfaValidationPluginManager extends DefaultPluginManager {
     $this->setCacheBackend($cache_backend, 'tfa_validation');
 
     // This is the essential line you have to use in your manager.
-//    $this->discovery = new AnnotatedClassDiscovery('Plugin/TfaValidation', $namespaces, 'Drupal\tfa\Annotation\TfaValidation');
+    //$this->discovery = new AnnotatedClassDiscovery('Plugin/TfaValidation', $namespaces, 'Drupal\tfa\Annotation\TfaValidation');
 //    dpm($this);
   }
 

--- a/tfa.module
+++ b/tfa.module
@@ -7,6 +7,7 @@
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\tfa\Tfa;
 use Drupal\user\Entity\User;
+use Drupal\Component\Utility\Crypt;
 
 /**
  * Implements hook_help().
@@ -23,14 +24,7 @@ function tfa_help($route_name, RouteMatchInterface $route_match) {
   }
 }
 
-/**
- * Implements hook_theme().
- */
-function tfa_theme() {
-  $theme = [];
 
-  return $theme;
-}
 
 /**
  * Validate access to TFA code entry form.
@@ -133,6 +127,7 @@ function tfa_login_form_redirect($form, &$form_state) {
 function tfa_login_submit($form, &$form_state) {
   // Similar to tfa_user_login() but not required to force user logout.
 
+
   if ($uid = $form_state->get('uid')) {
     $account = \Drupal::entityManager()->getStorage('user')->load($uid);
   }
@@ -145,16 +140,17 @@ function tfa_login_submit($form, &$form_state) {
       drupal_set_message(t('Login disallowed. You are required to setup two-factor authentication. Please contact a site administrator.'), 'error');
       $form_state['redirect'] = 'user';
     }
-    elseif (!tfa_login_complete($account) && $tfa->ready() && !tfa_login_allowed($account)) {
+    //elseif (!tfa_login_complete($account) && $tfa->ready() && !tfa_login_allowed($account)) {
+    elseif ( $tfa->ready() && !$tfa->loginAllowed($account)) {
 
       // Restart flood levels, session context, and TFA process.
-      flood_clear_event('tfa_validate');
-      flood_register_event('tfa_begin');
-      $context = tfa_start_context($account);
-      $tfa = tfa_get_process($account);
+      //flood_clear_event('tfa_validate');
+      //flood_register_event('tfa_begin');
+//      $context = tfa_start_context($account);
+//      $tfa = _tfa_get_process($account);
 
-      $query = drupal_get_query_parameters();
-      if (!empty($form_state['redirect'])) {
+     // $query = drupal_get_query_parameters();
+      if (!empty($form_state->redirect)) {
         // If there's an existing redirect set it in TFA context and
         // tfa_form_submit() will extract and set once process is complete.
         $context['redirect'] = $form_state['redirect'];
@@ -164,12 +160,15 @@ function tfa_login_submit($form, &$form_state) {
       // Begin TFA and set process context.
       $tfa->begin();
       $context = $tfa->getContext();
-      tfa_set_context($account, $context);
+      _tfa_set_context($account, $context);
 
       $login_hash = tfa_login_hash($account);
-      $form_state['tfa_redirect'] = array(
-        'system/tfa/' . $account->uid . '/' . $login_hash,
-        array('query' => $query),
+      $form_state->setRedirect(
+        'tfa.entry',
+        ['user' => $account->id(),
+        'hash' => $login_hash]
+        //'tfa/' . $account->id() . '/' . $login_hash
+        //array('query' => $query),
       );
     }
     else {
@@ -181,7 +180,10 @@ function tfa_login_submit($form, &$form_state) {
     drupal_set_message(t('Two-factor authentication is enabled but misconfigured. Please contact a site administrator.'), 'error');
     $form_state->setRedirect('user.page');
   }
+
 }
+
+
 
 /**
  * Get Tfa object in the account's current context.
@@ -193,7 +195,7 @@ function _tfa_get_process($account) {
   $tfa = &drupal_static(__FUNCTION__);
   if (!isset($tfa)) {
     $context = _tfa_get_context($account);
-    if (empty($context)) {
+    if (empty($context['plugins'])) {
       $context = _tfa_start_context($account);
     }
     try {
@@ -215,9 +217,9 @@ function _tfa_get_process($account) {
  */
 function _tfa_get_context(User $account) {
   $context = array();
-  if (isset($_SESSION['tfa'][$account->id()])) {
-    $context = $_SESSION['tfa'][$account->id()];
-  }
+//  if (isset($_SESSION['tfa'][$account->id()])) {
+//    $context = $_SESSION['tfa'][$account->id()];
+//  }
   // Allow other modules to modify TFA context.
   \Drupal::moduleHandler()->alter('tfa_context', $context);
   return $context;
@@ -236,6 +238,10 @@ function _tfa_get_context(User $account) {
  *       'fallback' => array('TfaMyRecoveryCodePlugin'),
  *       'setup' => 'TfaMySetupPlugin',
  *     ),
+ *
+ *
+ * @TODO TBD on purpose of $api defines the class name of the plugins, but we need to load
+ * them by the plugin name. Is it actually doing us any good?
  */
 function _tfa_start_context($account) {
   $context = array('uid' => $account->id(), 'plugins' => array());
@@ -243,6 +249,7 @@ function _tfa_start_context($account) {
   $fallback_plugins = array();
 
   $api = \Drupal::moduleHandler()->invokeAll('tfa_api', []);
+  $settings = \Drupal::config('tfa.settings');
   if (\Drupal::config('tfa.settings')->get('login_plugins')) {
     $plugins = \Drupal::config('tfa.settings')->get('login_plugins');
   }
@@ -252,16 +259,21 @@ function _tfa_start_context($account) {
   }
 
   // Add login plugins.
+  //@TODO This won't work the way it is. Need to refactor like we did for validate plguins.
   foreach ($plugins as $key) {
     if (array_key_exists($key, $api)) {
       $context['plugins']['login'][] = $api[$key]['class'];
     }
   }
   // Add validate.
-  $validate = \Drupal::config('tfa.settings')->get('validate_plugin');
-  if (!empty($validate) && array_key_exists($validate, $api)) {
-    $context['plugins']['validate'] = $api[$validate]['class'];
+  //@TODO Figure out why D8 decided to allow multiple validate plugins.
+  $validate = \Drupal::config('tfa.settings')->get('validate_plugins');
+  foreach($validate as $key => $value){
+    if (!empty($validate) && array_key_exists($key, $api)) {
+      $context['plugins']['validate'] = $key;
+    }
   }
+
   // Add fallback plugins.
   foreach ($fallback_plugins as $key) {
     if (array_key_exists($key, $api)) {
@@ -269,7 +281,7 @@ function _tfa_start_context($account) {
     }
   }
   // Allow other modules to modify TFA context.
-  \Drupal::moduleHandler()->alter('tfa_context', $context);
+  \Drupal::moduleHandler()->alter('tfa_context', $  context);
   _tfa_set_context($account, $context);
   return $context;
 }
@@ -300,4 +312,63 @@ function _tfa_login_complete($account) {
     return TRUE;
   }
   return FALSE;
+}
+
+
+/**
+ * Generate account hash to access the TFA form.
+ *
+ * @param object $account User account.
+ * @return string Random hash.
+ */
+function tfa_login_hash($account) {
+  // Using account login will mean this hash will become invalid once user has
+  // authenticated via TFA.
+  $data = implode(':', array($account->getUsername() , $account->getPassword(), $account->getLastLoginTime()));
+  return Crypt::hashBase64($data);
+}
+
+
+
+/**
+ * Authenticate the user.
+ *
+ * Does basically the same thing that user_login_finalize does but with our own custom
+ * hooks.
+ *
+ * @param $account User account object.
+ */
+function _tfa_login($account) {
+  \Drupal::currentUser()->setAccount($account);
+
+  // Update the user table timestamp noting user has logged in.
+  $account->setLastLoginTime(REQUEST_TIME);
+  \Drupal::entityManager()
+    ->getStorage('user')
+    ->updateLastLoginTimestamp($account);
+  // Regenerate the session ID to prevent against session fixation attacks.
+  \Drupal::service('session')->migrate();
+  \Drupal::service('session')->set('uid', $account->id());
+
+  //watchdog('tfa', 'Session opened for %name.', array('%name' => $user->getUsername()));
+  // Clear existing context and set master authenticated context.
+  _tfa_clear_context($account);
+  $_SESSION['tfa'][$account->id()]['login'] = TRUE;
+
+  // Truncate flood for user.
+  //flood_clear_event('tfa_begin');
+  //$identifier = variable_get('user_failed_login_identifier_uid_only', FALSE) ? $account->uid : $account->uid . '-' . ip_address();
+  //flood_clear_event('tfa_user', $identifier);
+  //$edit = array();
+  //user_module_invoke('login', $edit, $user);
+}
+
+/**
+ * Remove context for account.
+ *
+ * @param object $account
+ *   User account object
+ */
+function _tfa_clear_context($account) {
+  unset($_SESSION['tfa'][$account->uid]);
 }

--- a/tfa.module
+++ b/tfa.module
@@ -281,7 +281,7 @@ function _tfa_start_context($account) {
     }
   }
   // Allow other modules to modify TFA context.
-  \Drupal::moduleHandler()->alter('tfa_context', $  context);
+  \Drupal::moduleHandler()->alter('tfa_context', $context);
   _tfa_set_context($account, $context);
   return $context;
 }

--- a/tfa.module
+++ b/tfa.module
@@ -89,7 +89,7 @@ function tfa_form_alter(&$form, &$form_state, $form_id) {
         // tfa_login_form_redirect(). Other modules may alter the tfa_redirect
         // options element as needed to set the destination after TFA.
         $key = array_search('::submitForm', $form['#submit']);
-        $form['#submit'][$key] = 'tfa_login_submit';
+        $form['#submit'][$key] = 'Drupal\tfa\TfaManager::loginSubmit';
         $form['#submit'][] = 'tfa_login_form_redirect';
       }
       break;
@@ -102,6 +102,9 @@ function tfa_form_alter(&$form, &$form_state, $form_id) {
  * Should be last invoked form submit handler for forms user_login and
  * user_login_block so that when the TFA process is applied the user will be
  * sent to the TFA form.
+ *
+ *
+ * @param FormStateInterface $form_state
  */
 function tfa_login_form_redirect($form, &$form_state) {
   $route = $form_state->getValue('tfa_redirect');
@@ -110,68 +113,6 @@ function tfa_login_form_redirect($form, &$form_state) {
   }
 }
 
-/**
- * Implements hook_login_submit()
- *
- * Login submit handler to determine if TFA process is applicable.
- */
-function tfa_login_submit($form, &$form_state) {
-  // Similar to tfa_user_login() but not required to force user logout.
-  $tfaManager = \Drupal::service('tfa.manager');
-
-  if ($uid = $form_state->get('uid')) {
-    $account = \Drupal::entityManager()->getStorage('user')->load($uid);
-  }
-  else {
-    $account = user_load_by_name($form_state->get('name'));
-  }
-
-  if ($tfa = $tfaManager->getProcess($account)) {
-    if ($account->hasPermission('require tfa') && !$tfaManager->loginComplete($account) && !$tfa->ready()) {
-      drupal_set_message(t('Login disallowed. You are required to setup two-factor authentication. Please contact a site administrator.'), 'error');
-      $form_state['redirect'] = 'user';
-    }
-    elseif (!$tfaManager->loginComplete($account) && $tfa->ready() && !$tfa->loginAllowed($account)) {
-
-      // Restart flood levels, session context, and TFA process.
-      //flood_clear_event('tfa_validate');
-      //flood_register_event('tfa_begin');
-//      $context = tfa_start_context($account);
-//      $tfa = _tfa_get_process($account);
-
-     // $query = drupal_get_query_parameters();
-      if (!empty($form_state->redirect)) {
-        // If there's an existing redirect set it in TFA context and
-        // tfa_form_submit() will extract and set once process is complete.
-        $context['redirect'] = $form_state['redirect'];
-      }
-      unset($_GET['destination']);
-
-      // Begin TFA and set process context.
-      $tfa->begin();
-      $context = $tfa->getContext();
-      $tfaManager->setContext($account, $context);
-
-      $login_hash = $tfaManager->getLoginHash($account);
-      $form_state->setRedirect(
-        'tfa.entry',
-        ['user' => $account->id(),
-        'hash' => $login_hash]
-        //'tfa/' . $account->id() . '/' . $login_hash
-        //array('query' => $query),
-      );
-    }
-    else {
-      // Authentication can continue so invoke user_login_submit().
-      user_login_submit($form, $form_state);
-    }
-  }
-  else {
-    drupal_set_message(t('Two-factor authentication is enabled but misconfigured. Please contact a site administrator.'), 'error');
-    $form_state->setRedirect('user.page');
-  }
-
-}
 
 
 

--- a/tfa.module
+++ b/tfa.module
@@ -5,9 +5,6 @@
  * Contains tfa.module
  */
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\tfa\Tfa;
-use Drupal\user\Entity\User;
-use Drupal\Component\Utility\Crypt;
 
 /**
  * Implements hook_help().
@@ -122,11 +119,13 @@ function tfa_login_form_redirect($form, &$form_state) {
 }
 
 /**
+ * Implements hook_login_submit()
+ *
  * Login submit handler to determine if TFA process is applicable.
  */
 function tfa_login_submit($form, &$form_state) {
   // Similar to tfa_user_login() but not required to force user logout.
-
+  $tfaManager = \Drupal::service('tfa.manager');
 
   if ($uid = $form_state->get('uid')) {
     $account = \Drupal::entityManager()->getStorage('user')->load($uid);
@@ -135,8 +134,8 @@ function tfa_login_submit($form, &$form_state) {
     $account = user_load_by_name($form_state->get('name'));
   }
 
-  if ($tfa = _tfa_get_process($account)) {
-    if ($account->hasPermission('require tfa') && !_tfa_login_complete($account) && !$tfa->ready()) {
+  if ($tfa = $tfaManager->getProcess($account)) {
+    if ($account->hasPermission('require tfa') && !$tfaManager->loginComplete($account) && !$tfa->ready()) {
       drupal_set_message(t('Login disallowed. You are required to setup two-factor authentication. Please contact a site administrator.'), 'error');
       $form_state['redirect'] = 'user';
     }
@@ -160,9 +159,9 @@ function tfa_login_submit($form, &$form_state) {
       // Begin TFA and set process context.
       $tfa->begin();
       $context = $tfa->getContext();
-      _tfa_set_context($account, $context);
+      $tfaManager->setContext($account, $context);
 
-      $login_hash = tfa_login_hash($account);
+      $login_hash = $tfaManager->getLoginHash($account);
       $form_state->setRedirect(
         'tfa.entry',
         ['user' => $account->id(),
@@ -185,190 +184,7 @@ function tfa_login_submit($form, &$form_state) {
 
 
 
-/**
- * Get Tfa object in the account's current context.
- *
- * @param $account User account object
- * @return Tfa
- */
-function _tfa_get_process($account) {
-  $tfa = &drupal_static(__FUNCTION__);
-  if (!isset($tfa)) {
-    $context = _tfa_get_context($account);
-    if (empty($context['plugins'])) {
-      $context = _tfa_start_context($account);
-    }
-    try {
-      // instansiate all plugins
-      $tfa = new Tfa($context['plugins'], $context);
-    } catch (\Exception $e) {
-      $tfa = FALSE;
-    }
-  }
-  return $tfa;
-}
-
-/**
- * Context for account TFA process.
- *
- * @param User $account
- * @return array
- * @see _tfa_start_context() for format
- */
-function _tfa_get_context(User $account) {
-  $context = array();
-//  if (isset($_SESSION['tfa'][$account->id()])) {
-//    $context = $_SESSION['tfa'][$account->id()];
-//  }
-  // Allow other modules to modify TFA context.
-  \Drupal::moduleHandler()->alter('tfa_context', $context);
-  return $context;
-}
-
-/**
- * Start context for TFA.
- *
- * @param User $account
- * @return array
- *   array(
- *     'uid' => 9,
- *     'plugins' => array(
- *       'validate' => 'TfaMySendPlugin',
- *       'login' => arrray('TfaMyLoginPlugin'),
- *       'fallback' => array('TfaMyRecoveryCodePlugin'),
- *       'setup' => 'TfaMySetupPlugin',
- *     ),
- *
- *
- * @TODO TBD on purpose of $api defines the class name of the plugins, but we need to load
- * them by the plugin name. Is it actually doing us any good?
- */
-function _tfa_start_context($account) {
-  $context = array('uid' => $account->id(), 'plugins' => array());
-  $plugins = array();
-  $fallback_plugins = array();
-
-  $api = \Drupal::moduleHandler()->invokeAll('tfa_api', []);
-  $settings = \Drupal::config('tfa.settings');
-  if (\Drupal::config('tfa.settings')->get('login_plugins')) {
-    $plugins = \Drupal::config('tfa.settings')->get('login_plugins');
-  }
-
-  if (\Drupal::config('tfa.settings')->get('fallback_plugins')) {
-    $fallback_plugins = \Drupal::config('tfa.settings')->get('fallback_plugins');
-  }
-
-  // Add login plugins.
-  //@TODO This won't work the way it is. Need to refactor like we did for validate plguins.
-  foreach ($plugins as $key) {
-    if (array_key_exists($key, $api)) {
-      $context['plugins']['login'][] = $api[$key]['class'];
-    }
-  }
-  // Add validate.
-  //@TODO Figure out why D8 decided to allow multiple validate plugins.
-  $validate = \Drupal::config('tfa.settings')->get('validate_plugins');
-  foreach($validate as $key => $value){
-    if (!empty($validate) && array_key_exists($key, $api)) {
-      $context['plugins']['validate'] = $key;
-    }
-  }
-
-  // Add fallback plugins.
-  foreach ($fallback_plugins as $key) {
-    if (array_key_exists($key, $api)) {
-      $context['plugins']['fallback'][] = $api[$key]['class'];
-    }
-  }
-  // Allow other modules to modify TFA context.
-  \Drupal::moduleHandler()->alter('tfa_context', $context);
-  _tfa_set_context($account, $context);
-  return $context;
-}
-
-/**
- * Set context for account's TFA process.
- *
- * @param $account User account
- * @param array $context Context array
- * @see tfa_start_context() for context format
- */
-function _tfa_set_context($account, $context) {
-  $_SESSION['tfa'][$account->id()] = $context;
-  $_SESSION['tfa'][$account->id()]['uid'] = $account->id();
-  // Clear existing static TFA process.
-  drupal_static_reset('tfa_get_process');
-}
-
-/**
- * Check if TFA process has completed so authentication should not be stopped.
- *
- * @param $account User account
- * @return bool
- */
-function _tfa_login_complete($account) {
-  // TFA master login allowed switch is set by tfa_login().
-  if (isset($_SESSION['tfa'][$account->uid]['login']) && $_SESSION['tfa'][$account->uid]['login'] === TRUE) {
-    return TRUE;
-  }
-  return FALSE;
-}
-
-
-/**
- * Generate account hash to access the TFA form.
- *
- * @param object $account User account.
- * @return string Random hash.
- */
-function tfa_login_hash($account) {
-  // Using account login will mean this hash will become invalid once user has
-  // authenticated via TFA.
-  $data = implode(':', array($account->getUsername() , $account->getPassword(), $account->getLastLoginTime()));
-  return Crypt::hashBase64($data);
-}
 
 
 
-/**
- * Authenticate the user.
- *
- * Does basically the same thing that user_login_finalize does but with our own custom
- * hooks.
- *
- * @param $account User account object.
- */
-function _tfa_login($account) {
-  \Drupal::currentUser()->setAccount($account);
 
-  // Update the user table timestamp noting user has logged in.
-  $account->setLastLoginTime(REQUEST_TIME);
-  \Drupal::entityManager()
-    ->getStorage('user')
-    ->updateLastLoginTimestamp($account);
-  // Regenerate the session ID to prevent against session fixation attacks.
-  \Drupal::service('session')->migrate();
-  \Drupal::service('session')->set('uid', $account->id());
-
-  //watchdog('tfa', 'Session opened for %name.', array('%name' => $user->getUsername()));
-  // Clear existing context and set master authenticated context.
-  _tfa_clear_context($account);
-  $_SESSION['tfa'][$account->id()]['login'] = TRUE;
-
-  // Truncate flood for user.
-  //flood_clear_event('tfa_begin');
-  //$identifier = variable_get('user_failed_login_identifier_uid_only', FALSE) ? $account->uid : $account->uid . '-' . ip_address();
-  //flood_clear_event('tfa_user', $identifier);
-  //$edit = array();
-  //user_module_invoke('login', $edit, $user);
-}
-
-/**
- * Remove context for account.
- *
- * @param object $account
- *   User account object
- */
-function _tfa_clear_context($account) {
-  unset($_SESSION['tfa'][$account->uid]);
-}

--- a/tfa.module
+++ b/tfa.module
@@ -22,18 +22,10 @@ function tfa_help($route_name, RouteMatchInterface $route_match) {
 }
 
 
-
 /**
- * Validate access to TFA code entry form.
+ * Implements hook_user_login()
+ * @param $account
  */
-function tfa_entry_access($account, $url_hash) {
-  // Generate a hash for this account.
-  //$hash = tfa_login_hash($account);
-  //$context = tfa_get_context($account);
-  //return $hash === $url_hash && !empty($context) && $context['uid'] === $account->uid;
-  return TRUE;
-}
-
 function tfa_user_login($account) {
   if (!\Drupal::config('tfa.settings')->get('enabled')) {
     drupal_set_message(t('TFA is not enabled.'));
@@ -139,8 +131,7 @@ function tfa_login_submit($form, &$form_state) {
       drupal_set_message(t('Login disallowed. You are required to setup two-factor authentication. Please contact a site administrator.'), 'error');
       $form_state['redirect'] = 'user';
     }
-    //elseif (!tfa_login_complete($account) && $tfa->ready() && !tfa_login_allowed($account)) {
-    elseif ( $tfa->ready() && !$tfa->loginAllowed($account)) {
+    elseif (!$tfaManager->loginComplete($account) && $tfa->ready() && !$tfa->loginAllowed($account)) {
 
       // Restart flood levels, session context, and TFA process.
       //flood_clear_event('tfa_validate');

--- a/tfa.routing.yml
+++ b/tfa.routing.yml
@@ -1,16 +1,14 @@
 tfa.entry:
-  path: 'tfa/{account}'
+  path: 'tfa/{user}/{hash}'
   defaults:
     _form: '\Drupal\tfa\Form\EntryForm'
     _title: 'Two-Factor Authentication'
   requirements:
-    _entity_access: tfa_entry_access
-    #'access callback' => 'tfa_entry_access',
-    #'access arguments' => array(2, 3),
+    _permission: 'access content'
   options:
     _maintenance_access: TRUE
 tfa.settings:
-  path: 'admin/config/security/tfa/settings'
+  path: 'admin/config/security/tfa'
   defaults:
     _form: '\Drupal\tfa\Form\SettingsForm'
     _title: 'TFA Settings'

--- a/tfa.services.yml
+++ b/tfa.services.yml
@@ -11,3 +11,5 @@ services:
   plugin.manager.tfa.setup:
     class: Drupal\tfa\TfaSetupPluginManager
     parent: default_plugin_manager
+  tfa.manager:
+    class: Drupal\tfa\TfaManager


### PR DESCRIPTION
- Updated TFA module to prompt user for currently enabled TFA plugin. 
- Currently only tested with TfaTotp works (Google Authenticator) from the tfa_basic module
## Setup
- Enable tfa, tfa_basic
- Navigate to admin/config/security/tfa and enable TFA, and TOTP Validation/Setup plugins.
- Navigate to /user/1/security/tfa for your current user and setup TFA.
- Logout
- Navigate to /user - login with your username/password. 
  - You should then be prompted for a verification code. 
  - Enter in your verification code and you should get logged in.
## TODO
- Need to refactor some of the autoloading of plugins. 
- Need to determine why D8 decided to allow multiple validation plugins to be enabled. Doesn't seem like that is supported at the moment.
- Need to walk through the authentication process again and clean it up. A lot of code was commented out which needs to be refactored or removed (TBD on which one)
- Need to re-implement flood controls
- Need to refactor the TfaBasePlugin to take advantage of Key/Encrypt. Should probably move the 128bit encryption method to the Encrypt module as a base offering. (TBD if we should support 128 or if we could just use 256).
