### PR TITLE
Replacing deprecated SafeMarkup::format

### DIFF
--- a/src/Form/TfaLoginForm.php
+++ b/src/Form/TfaLoginForm.php
@@ -203,7 +203,14 @@ class TfaLoginForm extends UserLoginForm {
    * @param object $account User account.
    * @return string Random hash.
    */
-  //function tfa_login_hash($account) {
+  function tfa_login_hash($account) {
+    // Using account login will mean this hash will become invalid once user has
+    // authenticated via TFA.
+    $data = implode(':', array($account->name, $account->pass, $account->login));
+    return drupal_hash_base64($data);
+  }
+
+
   protected function getLoginHash($account) {
     // Using account login will mean this hash will become invalid once user has
     // authenticated via TFA.

--- a/src/Tfa.php
+++ b/src/Tfa.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\tfa;
 
-use Drupal\Component\Utility\SafeMarkup;
+use  \Drupal\Component\Render\FormattableMarkup;
 use Drupal\tfa\Plugin\TfaBasePlugin;
 use Drupal\Core\Form\FormStateInterface;
 
@@ -80,12 +80,12 @@ class Tfa {
   public function __construct(array $plugins, array $context) {
     if (empty($plugins)) {
       throw new \RuntimeException(
-        SafeMarkup::format('TFA must have at least 1 valid plugin',
+          new FormattableMarkup('TFA must have at least 1 valid plugin',
           array('@function' => 'Tfa::__construct')));
     }
     if (empty($plugins['validate'])) {
       throw new \RuntimeException(
-        SafeMarkup::format('TFA must have at least 1 valid validation plugin',
+          new FormattableMarkup('TFA must have at least 1 valid validation plugin',
           array('@function' => 'Tfa::__construct')));
     }
 


### PR DESCRIPTION
Since SafeMarkup methods are deprecated 
(Link- https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Component%21Utility%21SafeMarkup.php/function/SafeMarkup%3A%3Aformat/8) ,
we can use "FormattableMarkup" instead
